### PR TITLE
Explicitly cast dict value to string for type compatibility

### DIFF
--- a/colcon_sanitizer_reports/xml_output_generator.py
+++ b/colcon_sanitizer_reports/xml_output_generator.py
@@ -56,7 +56,8 @@ class XmlOutputGenerator:
         error_count_by_package = defaultdict(int)  # type: Dict[str, int]
         testcases = defaultdict()  # type: Dict[str, eTree.Element]
         for case in base_element.findall('testcase'):
-            testcases[case.get('name')] = case
+            # Explicitly cast to string for type compatibility
+            testcases[str(case.get('name'))] = case
 
         # Gather error details for all packages
         for key, count in self._count_by_error.items():

--- a/colcon_sanitizer_reports/xml_output_generator.py
+++ b/colcon_sanitizer_reports/xml_output_generator.py
@@ -56,11 +56,11 @@ class XmlOutputGenerator:
         error_count_by_package = defaultdict(int)  # type: Dict[str, int]
         testcases = defaultdict()  # type: Dict[str, eTree.Element]
         for case in base_element.findall('testcase'):
-            case_name = case.get('name', None)
+            case_name = case.get('name')
             if not case_name:
                 raise KeyError("Key 'name' for test case in XML tree does not exist")
             # Explicitly cast to string for type compatibility
-            testcases[str(case_name)] = case
+            testcases[case_name] = case
 
         # Gather error details for all packages
         for key, count in self._count_by_error.items():

--- a/colcon_sanitizer_reports/xml_output_generator.py
+++ b/colcon_sanitizer_reports/xml_output_generator.py
@@ -56,8 +56,11 @@ class XmlOutputGenerator:
         error_count_by_package = defaultdict(int)  # type: Dict[str, int]
         testcases = defaultdict()  # type: Dict[str, eTree.Element]
         for case in base_element.findall('testcase'):
+            case_name = case.get('name', None)
+            if not case_name:
+                raise KeyError("Key 'name' for test case in XML tree does not exist")
             # Explicitly cast to string for type compatibility
-            testcases[str(case.get('name'))] = case
+            testcases[str(case_name)] = case
 
         # Gather error details for all packages
         for key, count in self._count_by_error.items():


### PR DESCRIPTION
Explicitly cast dict value to string for type compatibility.
This fixes the `mypy` type checking [here](https://dev.azure.com/osrf/colcon-sanitizer-reports/_build/results?buildId=51&view=logs&j=e8dcbce0-de23-5097-16c8-87923e8758b6&t=ff23cfec-de40-5d9d-0b76-bf92f7fabc01).

We need to cast to string because the return type of `get()` is `Optional[str]` and not `str`.

```python
name = case.get('name')  # type: Optional[str]
testcases[str(name)] = case
```
 
Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>